### PR TITLE
Unescaped '%' in gruntfile template

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -60,7 +60,7 @@ GruntfileGenerator.prototype.askFor = function askFor() {
     this.packageJSON = props.packageJSON;
 
     this.testTask = props.dom ? 'qunit' : 'nodeunit';
-    this.fileName = props.packageJSON ? '<%%= pkg.name %>' : 'FILE_NAME';
+    this.fileName = props.packageJSON ? '<%= pkg.name %>' : 'FILE_NAME';
 
     cb();
   }.bind(this));


### PR DESCRIPTION
These come out as '%%' in the output file, so it's kind of inconvenient to keep changing them for every project
